### PR TITLE
fix: rename Clapper to "SERP Extension"

### DIFF
--- a/clapper.html
+++ b/clapper.html
@@ -1,12 +1,12 @@
 <html>
 
 <head>
-    <title>Clapper</title>
+    <title>SERP Extension</title>
     <link rel="stylesheet" href="style.css" />
 </head>
 
 <body class="body">
-    <h2>Clapper</h2>
+    <h2>SERP Extension</h2>
 
     <div class="platform-list">
         <div>


### PR DESCRIPTION
This fix is part of https://github.com/serpcompany/serp-extension/issues/20 issue.

| Preview |
| --- |
|  <img alt="CleanShot 2024-03-26 at 13 36 20@2x" src="https://github.com/serpcompany/serp-extension/assets/29014463/b9753ef9-b9d7-4d27-aec0-51dd5aa53acb" width="250" /> |