### PR TITLE
feat: highlight no-follow links

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,39 +1,62 @@
 // background.js
 
+function runNoFollowScript(tabId, tabUrl) {
+  const url = new URL(tabUrl);
+  const key = `___serp_ext_disable-noFollow-${url.host}`;
+
+  chrome.storage.local.get([key], function (result) {
+    if (result.hasOwnProperty(key)) {
+    } else {
+      chrome.scripting.executeScript({
+        target: { tabId },
+        files: ["js/executeScripts/noFollow.js"],
+      });
+    }
+  });
+}
+
 chrome.tabs.onActivated.addListener(function (activeInfo) {
   chrome.tabs.get(activeInfo.tabId, function (tab) {
     var tabUrl = tab.url;
-    setActivePlatform(tabUrl)
-  })
+
+    if (tabUrl.startsWith("http://") || tabUrl.startsWith("https://")) {
+      setActivePlatform(tabUrl);
+      runNoFollowScript(tab.id, tabUrl);
+    }
+  });
 });
 
 function setActivePlatform(url) {
-  if (url.startsWith('http://') || url.startsWith('https://')) {
-    let activePlatform = '';
+  let activePlatform = "";
 
-    if (url.includes('medium.com')) {
-      activePlatform = 'medium'
-    } else if (url.includes('new.reddit.com')) {
-      activePlatform = 'reddit'
-    }
-
-    chrome.storage.local.set({activePlatform: activePlatform}, function () {
-      console.log('Active platform is:', activePlatform);
-    })
+  if (url.includes("medium.com")) {
+    activePlatform = "medium";
+  } else if (url.includes("new.reddit.com")) {
+    activePlatform = "reddit";
   }
+
+  chrome.storage.local.set({ activePlatform: activePlatform }, function () {
+    console.log("Active platform is:", activePlatform);
+  });
 }
 
 /**
  * Continue to run Amazon script in background on all sites.
  * NOTE: It may impact the performance of the browser.
  */
-chrome.tabs.query({}, function(tabs) {
-  tabs.forEach(function(tab) {
-    console.log('tab', tab);
-
+chrome.tabs.query({}, function (tabs) {
+  tabs.forEach(function (tab) {
     chrome.scripting.executeScript({
-      target: {tabId: tab.id},
-      files: ['js/amazon.js']
+      target: { tabId: tab.id },
+      files: ["js/amazon.js"],
     });
   });
+});
+
+chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+  if (changeInfo.status === "loading" || changeInfo.status === "complete") {
+    if (tab.url.startsWith("http://") || tab.url.startsWith("https://")) {
+      runNoFollowScript(tabId, tab.url);
+    }
+  }
 });

--- a/clapper.html
+++ b/clapper.html
@@ -18,7 +18,7 @@
 
                 <div>
                     <button id="noFollowBtn">
-                        Enable
+                        Disable
                     </button>
                 </div>
             </div>

--- a/clapper.html
+++ b/clapper.html
@@ -9,6 +9,22 @@
     <h2>SERP Extension</h2>
 
     <div class="platform-list">
+        <!-- NoFollow -->
+        <div>
+            <div class="platform-item">
+                <div class="platform-item-content">
+                    <p>NoFollow</p>
+                </div>
+
+                <div>
+                    <button id="noFollowBtn">
+                        Enable
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Reddit -->
         <div>
             <div class="platform-item">
                 <div class="platform-item-content">
@@ -73,6 +89,7 @@
     </p>
 
     <script src="popup.js"></script>
+    <script src="js/nofollow.js"></script>
 </body>
 
 </html>

--- a/js/executeScripts/noFollow.js
+++ b/js/executeScripts/noFollow.js
@@ -1,16 +1,17 @@
 var ID = "___serp_ext_nofollow"
 
 function addStyles() {
+  console.log('addStyles');
   const css = document.createElement("style");
   css.id = ID;
-  
+
   // To keep the styles update-to-date
-  let noFollowStyleTag = document.getElementById(ID)
+  let noFollowStyleTag = document.getElementById(ID);
   if (noFollowStyleTag) {
     noFollowStyleTag.parentNode.removeChild(noFollowStyleTag);
   }
 
-  css.innerHTML = "a[rel~='nofollow'] {outline: .14em dotted red !important;outline-offset: .2em;}a[rel~='nofollow'] img {outline: 2px dotted red !important;outline-offset: .2em;}"
+  css.innerHTML = "a[rel~='nofollow'] {outline: .14em dotted red !important;outline-offset: .2em;}a[rel~='nofollow'] img {outline: 2px dotted red !important;outline-offset: .2em;}";
 
   var head = document.head;
   head.appendChild(css);
@@ -19,7 +20,7 @@ function addStyles() {
 addStyles();
 
 function removeStyles() {
-  let noFollowStyleTag = document.getElementById(ID)
+  let noFollowStyleTag = document.getElementById(ID);
   if (noFollowStyleTag) {
     noFollowStyleTag.parentNode.removeChild(noFollowStyleTag);
   }
@@ -27,6 +28,6 @@ function removeStyles() {
 
 chrome.runtime.onMessage.addListener((request) => {
   if (request.message === "___serp_ext_stop_script") {
-    removeStyles()
+    removeStyles();
   }
 });

--- a/js/executeScripts/noFollow.js
+++ b/js/executeScripts/noFollow.js
@@ -1,0 +1,32 @@
+var ID = "___serp_ext_nofollow"
+
+function addStyles() {
+  const css = document.createElement("style");
+  css.id = ID;
+  
+  // To keep the styles update-to-date
+  let noFollowStyleTag = document.getElementById(ID)
+  if (noFollowStyleTag) {
+    noFollowStyleTag.parentNode.removeChild(noFollowStyleTag);
+  }
+
+  css.innerHTML = "a[rel~='nofollow'] {outline: .14em dotted red !important;outline-offset: .2em;}a[rel~='nofollow'] img {outline: 2px dotted red !important;outline-offset: .2em;}"
+
+  var head = document.head;
+  head.appendChild(css);
+}
+
+addStyles();
+
+function removeStyles() {
+  let noFollowStyleTag = document.getElementById(ID)
+  if (noFollowStyleTag) {
+    noFollowStyleTag.parentNode.removeChild(noFollowStyleTag);
+  }
+}
+
+chrome.runtime.onMessage.addListener((request) => {
+  if (request.message === "___serp_ext_stop_script") {
+    removeStyles()
+  }
+});

--- a/js/nofollow.js
+++ b/js/nofollow.js
@@ -1,47 +1,84 @@
-function getActiveTagId() {
+function getActiveTag() {
   return new Promise((resolve, reject) => {
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       var activeTab = tabs[0];
       if (activeTab) {
-        resolve(activeTab.id);
+        resolve(activeTab);
       } else {
-        reject(new Error('No active tab found.'));
+        reject(new Error("No active tab found."));
       }
     });
   });
 }
 
 const noFollowBtn = document.getElementById("noFollowBtn");
-noFollowBtn.onclick = enableNoFollow;
+noFollowBtn.onclick = disableNoFollow;
 
 async function enableNoFollow() {
-  const activeTabId = await getActiveTagId();
-  if (!activeTabId) {
+  const activeTab = await getActiveTag();
+  if (!activeTab?.id) {
     return;
   }
 
   chrome.scripting.executeScript(
     {
-      target: { tabId: activeTabId },
+      target: { tabId: activeTab.id },
       files: ["js/executeScripts/noFollow.js"],
     },
     function () {
       noFollowBtn.innerHTML = "Disable";
       noFollowBtn.onclick = disableNoFollow;
+
+      const url = new URL(activeTab.url);
+      chrome.storage.local.remove(
+        `___serp_ext_disable-noFollow-${url.host}`,
+        function () {}
+      );
     }
   );
 }
 
 async function disableNoFollow() {
-  const activeTabId = await getActiveTagId();
-  if (!activeTabId) {
+  const activeTab = await getActiveTag();
+  if (!activeTab?.id) {
     return;
   }
 
-  chrome.tabs.sendMessage(activeTabId, {
+  chrome.tabs.sendMessage(activeTab.id, {
     message: "___serp_ext_stop_script",
   });
+  
+  const url = new URL(activeTab.url);
+  chrome.storage.local.set(
+    { [`___serp_ext_disable-noFollow-${url.host}`]: true },
+    function () {
+      console.log("Feature disable: [No follow]: " + url.host);
+    }
+  );
 
   noFollowBtn.innerHTML = "Enable";
   noFollowBtn.onclick = enableNoFollow;
 }
+
+async function checkState() {
+  const activeTab = await getActiveTag();
+  if (!activeTab?.id) {
+    return;
+  }
+
+  const url = new URL(activeTab.url);
+  const key = `___serp_ext_disable-noFollow-${url.host}`;
+  chrome.storage.local.get([key], function (result) {
+    console.log('res', result);
+    if (result.hasOwnProperty(key)) {
+      noFollowBtn.innerHTML = "Enable";
+      noFollowBtn.onclick = enableNoFollow;
+    } else {
+      noFollowBtn.innerHTML = "Disable";
+      noFollowBtn.onclick = disableNoFollow;
+    }
+  });
+}
+
+
+checkState()

--- a/js/nofollow.js
+++ b/js/nofollow.js
@@ -1,0 +1,47 @@
+function getActiveTagId() {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      var activeTab = tabs[0];
+      if (activeTab) {
+        resolve(activeTab.id);
+      } else {
+        reject(new Error('No active tab found.'));
+      }
+    });
+  });
+}
+
+const noFollowBtn = document.getElementById("noFollowBtn");
+noFollowBtn.onclick = enableNoFollow;
+
+async function enableNoFollow() {
+  const activeTabId = await getActiveTagId();
+  if (!activeTabId) {
+    return;
+  }
+
+  chrome.scripting.executeScript(
+    {
+      target: { tabId: activeTabId },
+      files: ["js/executeScripts/noFollow.js"],
+    },
+    function () {
+      noFollowBtn.innerHTML = "Disable";
+      noFollowBtn.onclick = disableNoFollow;
+    }
+  );
+}
+
+async function disableNoFollow() {
+  const activeTabId = await getActiveTagId();
+  if (!activeTabId) {
+    return;
+  }
+
+  chrome.tabs.sendMessage(activeTabId, {
+    message: "___serp_ext_stop_script",
+  });
+
+  noFollowBtn.innerHTML = "Enable";
+  noFollowBtn.onclick = enableNoFollow;
+}


### PR DESCRIPTION
**Description**

Adds the option to enable/disable `nofollow` attribute links in the tab.

**NOTE**

This PR only contains the base functionality of the [original chrome extension](https://chromewebstore.google.com/detail/nofollow/dfogidghaigoomjdeacndafapdijmiid) and does not include any additional customisation.

**Demo**

https://www.loom.com/share/af6b198e60c74544b4a5f21a4936a0df?sid=d3e084fb-88a9-4b10-acdd-2db28f940d5a

Closes https://github.com/serpcompany/public/issues/14